### PR TITLE
Fix: Vagrant up failure due to deprecated vagrant-env dependency

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,9 @@ inventory_app_path = vagrant_config['inventory_app_path']
 apigateway_app_path = vagrant_config['apigateway_app_path']
 
 Vagrant.configure("2") do |config|
-  config.env.enable
+  if Vagrant.has_plugin?("vagrant-dotenv")
+    config.env.enabled = true
+  end
   config.vm.box = box
   config.ssh.forward_agent = true
 


### PR DESCRIPTION
This PR fixes the `vagrant up` error caused by the deprecated `vagrant-env` dependency.
Replaced it with `vagrant-dotenv` which is maintained and compatible.